### PR TITLE
Support Option-augmented AnyDrag shortcuts for macOS tiling

### DIFF
--- a/AnyDrag/Sources/DragEngine.swift
+++ b/AnyDrag/Sources/DragEngine.swift
@@ -39,6 +39,15 @@ enum ModifierKey: String, CaseIterable {
         case .optionCommand:  return "⌥⌘"
         }
     }
+
+    var supportsOptionAugmentation: Bool {
+        switch self {
+        case .option, .optionCommand:
+            return false
+        case .command, .control, .fn:
+            return true
+        }
+    }
 }
 
 // MARK: - DragEngine
@@ -46,6 +55,13 @@ enum ModifierKey: String, CaseIterable {
 /// Intercepts mouse events via a CGEvent tap and delegates to TitleBarDragStrategy
 /// when a configured modifier key is held during a click.
 final class DragEngine {
+
+    private static let secondaryFnMask = CGEventFlags(rawValue: 0x800000)
+    private static let relevantModifierMask = CGEventFlags.maskAlternate |
+                                              CGEventFlags.maskCommand |
+                                              CGEventFlags.maskControl |
+                                              CGEventFlags.maskShift |
+                                              secondaryFnMask
 
     var isEnabled: Bool = true
     var modifierKey: ModifierKey = .option
@@ -143,18 +159,9 @@ final class DragEngine {
         }
 
         // Check if the configured modifier key is held.
-        // Strip maskNonCoalesced and compare only modifier bits.
-        let flags = event.flags
-        let targetRaw = modifierKey.eventFlags.rawValue
-        let cleaned = flags.rawValue & ~CGEventFlags.maskNonCoalesced.rawValue
-        let relevantMask: UInt64 = CGEventFlags.maskAlternate.rawValue |
-                                    CGEventFlags.maskCommand.rawValue |
-                                    CGEventFlags.maskControl.rawValue |
-                                    CGEventFlags.maskShift.rawValue |
-                                    0x800000 // maskSecondaryFn
-        let activeModifiers = cleaned & relevantMask
-
-        guard activeModifiers == targetRaw else {
+        // We also allow an extra Option key for non-Option shortcuts so
+        // macOS native tiling can still kick in during an AnyDrag drag.
+        guard matchesConfiguredModifier(event.flags) else {
             return Unmanaged.passRetained(event)
         }
 
@@ -218,17 +225,7 @@ final class DragEngine {
             return nil
         }
 
-        let flags = event.flags
-        let targetRaw = modifierKey.eventFlags.rawValue
-        let cleaned = flags.rawValue & ~CGEventFlags.maskNonCoalesced.rawValue
-        let relevantMask: UInt64 = CGEventFlags.maskAlternate.rawValue |
-                                    CGEventFlags.maskCommand.rawValue |
-                                    CGEventFlags.maskControl.rawValue |
-                                    CGEventFlags.maskShift.rawValue |
-                                    0x800000
-        let activeModifiers = cleaned & relevantMask
-
-        guard activeModifiers == targetRaw else {
+        guard matchesConfiguredModifier(event.flags) else {
             return Unmanaged.passRetained(event)
         }
 
@@ -267,6 +264,24 @@ final class DragEngine {
         }
         panel.show(at: point)
         tilingPanel = panel
+    }
+
+    private func matchesConfiguredModifier(_ flags: CGEventFlags) -> Bool {
+        let cleanedFlags = flags.subtracting(.maskNonCoalesced)
+        let activeModifiers = cleanedFlags.intersection(Self.relevantModifierMask)
+        let targetModifiers = modifierKey.eventFlags
+
+        if activeModifiers == targetModifiers {
+            return true
+        }
+
+        guard modifierKey.supportsOptionAugmentation else {
+            return false
+        }
+
+        // Allow base shortcut + Option so users can combine AnyDrag with
+        // the macOS "Hold Option key while dragging windows to tile" feature.
+        return activeModifiers == targetModifiers.union(.maskAlternate)
     }
 
     private func performTileAction(_ action: TileAction, windowInfo: (pid: pid_t, windowID: CGWindowID, frame: CGRect)) {

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ On first launch, macOS will ask for **Accessibility permission** — this is req
    ![Tiling Panel](tiling_panel.png)
 5. Click the menu bar icon to change the modifier key or toggle on/off
 
+If macOS "Hold Option key while dragging windows to tile" is enabled and AnyDrag's modifier is not `Option`, you can also hold `Option` as an extra key to use native tiling. For example, with AnyDrag set to `fn`, `fn + option + drag` starts a native drag from anywhere in the window and still triggers system tiling.
+
 ### Supported Modifiers
 
 - Option

--- a/README_CN.md
+++ b/README_CN.md
@@ -28,6 +28,8 @@ BetterTouchTool 等工具也有类似的修饰键+拖动功能，但它们通过
    ![窗口布局面板](tiling_panel.png)
 5. 点击菜单栏图标可以切换修饰键或开关
 
+如果你在 macOS 中开启了“按住 ⌥ 键拖移窗口以平铺”，并且 AnyDrag 的修饰键不是 `Option`，那么也可以额外按住 `Option` 使用系统平铺。例如把 AnyDrag 设为 `fn` 后，可以直接用 `fn + option + 拖动` 从窗口任意区域触发原生拖动和平铺。
+
 ### 支持的修饰键
 
 - Option


### PR DESCRIPTION
This pull request improves the way modifier keys are handled for drag actions in AnyDrag, specifically allowing users to combine the app's shortcuts with macOS's native "Hold Option key while dragging windows to tile" feature. Now, if the configured modifier is not `Option`, holding `Option` in addition to the configured key will still trigger native tiling. The implementation also cleans up and centralizes modifier matching logic. Documentation has been updated to explain this new behavior.

**Modifier key handling improvements:**
* Added the `supportsOptionAugmentation` property to `ModifierKey` to determine if a modifier supports combining with the Option key for native tiling.
* Centralized and refactored modifier matching logic into a new `matchesConfiguredModifier(_:)` method in `DragEngine`, allowing non-Option shortcuts to work with Option for native tiling.
* Updated drag event handling to use the new matching logic, replacing previous bitmask checks. [[1]](diffhunk://#diff-551d90ba19ab707f98798a9f34cc4f62c88d7ba1a0a7fa64d219b11c909b1105L146-R164) [[2]](diffhunk://#diff-551d90ba19ab707f98798a9f34cc4f62c88d7ba1a0a7fa64d219b11c909b1105L221-R228)
* Defined `secondaryFnMask` and `relevantModifierMask` as static properties for cleaner code and easier maintenance.

**Documentation updates:**
* Updated both `README.md` and `README_CN.md` to describe the new behavior, clarifying how users can combine AnyDrag with the system tiling feature by holding the Option key. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R31-R32) [[2]](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7R31-R32)