### PR TITLE
feat: Hyper modifier — hold CapsLock (via HyperCapslock) to drag

### DIFF
--- a/AnyDrag/Resources/en.lproj/Localizable.strings
+++ b/AnyDrag/Resources/en.lproj/Localizable.strings
@@ -40,9 +40,11 @@
 "Option" = "Option";
 "Control" = "Control";
 "fn" = "fn";
+"Hyper" = "Hyper";
 /* %1$@ = symbol (e.g. ⇧⌘), %2$@ = name (e.g. Shift + Command) */
 "modifier.preview.format" = "Hold %1$@ (%2$@) to use AnyDrag";
 "modifier.preview.empty" = "AnyDrag is off — choose a modifier key to enable";
+"modifier.hyper.hint" = "Hyper = hold CapsLock. Requires HyperCapslock running with “Hold CapsLock to drag windows (AnyDrag)” enabled.";
 
 /* Settings — Features section */
 "Features" = "Features";

--- a/AnyDrag/Resources/zh-Hans.lproj/Localizable.strings
+++ b/AnyDrag/Resources/zh-Hans.lproj/Localizable.strings
@@ -40,9 +40,11 @@
 "Option" = "Option";
 "Control" = "Control";
 "fn" = "fn";
+"Hyper" = "Hyper";
 /* %1$@ = symbol (e.g. ⇧⌘), %2$@ = name (e.g. Shift + Command) */
 "modifier.preview.format" = "按住 %1$@ (%2$@) 使用 AnyDrag";
 "modifier.preview.empty" = "AnyDrag 已关闭 — 选择修饰键以启用";
+"modifier.hyper.hint" = "Hyper = 按住 CapsLock。需运行 HyperCapslock 并启用“按住 CapsLock 拖动窗口（AnyDrag）”。";
 
 /* Settings — Features section */
 "Features" = "功能";

--- a/AnyDrag/Sources/Analytics.swift
+++ b/AnyDrag/Sources/Analytics.swift
@@ -162,6 +162,7 @@ extension ModifierCombination {
     /// Order matches Apple HIG (fn, control, option, shift, command).
     var analyticsKey: String {
         var parts: [String] = []
+        if contains(.hyper)   { parts.append("hyper") }
         if contains(.fn)      { parts.append("fn") }
         if contains(.control) { parts.append("control") }
         if contains(.option)  { parts.append("option") }

--- a/AnyDrag/Sources/DragEngine.swift
+++ b/AnyDrag/Sources/DragEngine.swift
@@ -73,6 +73,15 @@ struct ModifierCombination: OptionSet, Equatable, Hashable {
         !contains(.option)
     }
 
+    /// Enforce the Hyper-is-exclusive invariant: Hyper never coexists with flag
+    /// modifiers (the engine arms on a CapsLock hold OR a flag combo, never a
+    /// mix). Used to sanitize values loaded from persistence that may have been
+    /// written before the exclusivity rule, or hand-edited. Hyper wins when both
+    /// are present, since selecting it is the deliberate, newer choice.
+    var hyperNormalized: ModifierCombination {
+        contains(.hyper) ? .hyper : self
+    }
+
     /// Migrate the pre-1.3 `ModifierKey` string preference.
     init?(legacyString: String) {
         switch legacyString {

--- a/AnyDrag/Sources/DragEngine.swift
+++ b/AnyDrag/Sources/DragEngine.swift
@@ -12,7 +12,10 @@ extension Notification.Name {
 // MARK: - Modifier Combination Model
 
 /// User-selectable combination of modifier keys. Any non-empty subset of
-/// command/shift/option/control/fn is allowed.
+/// command/shift/option/control/fn is allowed, plus `hyper` — a *virtual*
+/// modifier meaning "CapsLock held, as signalled by HyperCapslock". Unlike the
+/// others, `hyper` is NOT a `CGEventFlag` (it carries no flag on the mouse
+/// event); the engine satisfies it from `HyperCapslockCapsHoldSource` instead.
 struct ModifierCombination: OptionSet, Equatable, Hashable {
     let rawValue: UInt
     init(rawValue: UInt) { self.rawValue = rawValue }
@@ -22,9 +25,13 @@ struct ModifierCombination: OptionSet, Equatable, Hashable {
     static let option  = ModifierCombination(rawValue: 1 << 2)
     static let control = ModifierCombination(rawValue: 1 << 3)
     static let fn      = ModifierCombination(rawValue: 1 << 4)
+    /// Virtual: "hold CapsLock (via HyperCapslock)". No event flag — see above.
+    static let hyper   = ModifierCombination(rawValue: 1 << 5)
 
     static let fnEventFlag = CGEventFlags.maskSecondaryFn
 
+    /// The real CGEventFlags this combination requires. `hyper` contributes
+    /// nothing here — it is matched out-of-band against the CapsLock source.
     var eventFlags: CGEventFlags {
         var f: CGEventFlags = []
         if contains(.command) { f.insert(.maskCommand) }
@@ -35,9 +42,11 @@ struct ModifierCombination: OptionSet, Equatable, Hashable {
         return f
     }
 
-    /// Glyph display, e.g. "⌃⌥⇧⌘" or "fn⌘". Order follows Apple HIG (fn ⌃ ⌥ ⇧ ⌘).
+    /// Glyph display, e.g. "⌃⌥⇧⌘" or "fn⌘". Order follows Apple HIG (fn ⌃ ⌥ ⇧ ⌘),
+    /// with the virtual Hyper key first.
     var symbol: String {
         var s = ""
+        if contains(.hyper)   { s += "Hyper" }
         if contains(.fn)      { s += "fn" }
         if contains(.control) { s += "⌃" }
         if contains(.option)  { s += "⌥" }
@@ -49,6 +58,7 @@ struct ModifierCombination: OptionSet, Equatable, Hashable {
     /// Localized name, e.g. "Control + Option + Command".
     var displayName: String {
         var parts: [String] = []
+        if contains(.hyper)   { parts.append(NSLocalizedString("Hyper", comment: "")) }
         if contains(.fn)      { parts.append(NSLocalizedString("fn", comment: "")) }
         if contains(.control) { parts.append(NSLocalizedString("Control", comment: "")) }
         if contains(.option)  { parts.append(NSLocalizedString("Option", comment: "")) }
@@ -173,7 +183,18 @@ final class DragEngine {
 
     private static let log = FileLog("DragEngine")
 
-    var modifiers: ModifierCombination = .option
+    var modifiers: ModifierCombination = .option {
+        didSet {
+            // The virtual `.hyper` chip drives the CapsLock source on/off. Set on
+            // the main thread (config apply + chip toggle), same as every other
+            // `modifiers` write.
+            hyperCapslockSource.setEnabled(modifiers.contains(.hyper))
+        }
+    }
+    /// AnyDrag's link to HyperCapslock. Owns the cross-process CapsLock-hold
+    /// listening and the liveness watchdog; consulted via `isHeld` on the tap
+    /// thread. Active only while `.hyper` is selected.
+    let hyperCapslockSource = HyperCapslockCapsHoldSource()
     var dragEnabled: Bool = true
     var maximizeEnabled: Bool = true
     var tilingEnabled: Bool = true
@@ -1302,6 +1323,14 @@ final class DragEngine {
     }
 
     private func matchesConfiguredModifier(_ flags: CGEventFlags) -> Bool {
+        // Virtual `.hyper` modifier: when selected and CapsLock is held (per the
+        // HyperCapslock source), arm regardless of flags — CapsLock isn't a flag.
+        // OR-ed in, so it coexists with any flag chips. Only needs to hold at the
+        // instant of mouse-down.
+        if modifiers.contains(.hyper) && hyperCapslockSource.isHeld {
+            return true
+        }
+
         let cleanedFlags = flags.subtracting(.maskNonCoalesced)
         let activeModifiers = cleanedFlags.intersection(Self.relevantModifierMask)
         let targetModifiers = modifiers.eventFlags

--- a/AnyDrag/Sources/HyperCapslockCapsHoldSource.swift
+++ b/AnyDrag/Sources/HyperCapslockCapsHoldSource.swift
@@ -1,0 +1,114 @@
+import Foundation
+import os
+
+/// AnyDrag's half of the optional HyperCapslock link, and the ONLY AnyDrag file
+/// that knows the HyperCapslock wire protocol. It owns:
+///
+///   • the cross-process listener for the CapsLock-hold lifecycle, and
+///   • a liveness watchdog: while held it pings HyperCapslock; if no pong comes
+///     back within `deadThreshold`, it treats HyperCapslock as gone and ends the
+///     hold (so a `kill -9` can't leave AnyDrag armed forever).
+///
+/// `DragEngine` only consults `isHeld` (on the tap thread) and toggles
+/// `setEnabled` from the `.hyper` modifier chip; it knows nothing else.
+final class HyperCapslockCapsHoldSource {
+    private enum Wire {  // contract — must match HyperCapslock byte-for-byte
+        static let began = Notification.Name("me.xueshi.hypercapslock.capsHoldBegan")
+        static let ended = Notification.Name("me.xueshi.hypercapslock.capsHoldEnded")
+        static let ping  = Notification.Name("me.xueshi.hypercapslock.capsHoldPing")
+        static let pong  = Notification.Name("me.xueshi.hypercapslock.capsHoldPong")
+    }
+
+    /// While held, ping this often; if no pong within `deadThreshold`, presume
+    /// HyperCapslock gone and unhold. 100 ms / 1 s ⇒ disarm within ~1 s of a kill.
+    private static let pingInterval: TimeInterval = 0.1
+    private static let deadThreshold: TimeInterval = 1.0
+
+    private static let log = FileLog("HyperCapslockLink")
+
+    /// Read on the tap thread; written on main. The only cross-thread state.
+    private let heldLock = OSAllocatedUnfairLock(initialState: false)
+    var isHeld: Bool { heldLock.withLock { $0 } }
+
+    // Everything below is main-thread only.
+    private var enabled = false
+    private var observers: [NSObjectProtocol] = []
+    private var heartbeat: DispatchSourceTimer?
+    private var lastPongAt: TimeInterval = 0
+
+    init() { installObservers() }
+    deinit { removeObservers(); heartbeat?.cancel() }
+
+    /// Driven by the `.hyper` modifier chip. When disabled, the source ignores
+    /// everything and reports not-held.
+    func setEnabled(_ on: Bool) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard on != enabled else { return }
+        enabled = on
+        if !on { endHold() }   // disarm + stop the heartbeat
+        Self.log.info("Hyper source \(on ? "enabled" : "disabled").")
+    }
+
+    // MARK: - Cross-process observers (fire on main)
+
+    private func installObservers() {
+        let c = DistributedNotificationCenter.default()
+        observers = [
+            c.addObserver(forName: Wire.began, object: nil, queue: .main) { [weak self] _ in self?.onBegan() },
+            c.addObserver(forName: Wire.ended, object: nil, queue: .main) { [weak self] _ in self?.endHold() },
+            c.addObserver(forName: Wire.pong,  object: nil, queue: .main) { [weak self] _ in self?.lastPongAt = Self.now() },
+        ]
+    }
+
+    private func removeObservers() {
+        let c = DistributedNotificationCenter.default()
+        observers.forEach { c.removeObserver($0) }
+        observers.removeAll()
+    }
+
+    private func onBegan() {
+        guard enabled else { return }
+        heldLock.withLock { $0 = true }
+        startHeartbeat()
+    }
+
+    private func endHold() {
+        heldLock.withLock { $0 = false }
+        stopHeartbeat()
+    }
+
+    // MARK: - Liveness watchdog (main queue)
+
+    private func startHeartbeat() {
+        stopHeartbeat()
+        lastPongAt = Self.now()          // grace: assume alive at the start
+        post(Wire.ping)                  // probe immediately
+        let t = DispatchSource.makeTimerSource(queue: .main)
+        t.schedule(deadline: .now() + Self.pingInterval, repeating: Self.pingInterval)
+        t.setEventHandler { [weak self] in self?.tick() }
+        heartbeat = t
+        t.resume()
+    }
+
+    private func stopHeartbeat() {
+        heartbeat?.cancel()
+        heartbeat = nil
+    }
+
+    private func tick() {
+        if Self.now() - lastPongAt > Self.deadThreshold {
+            Self.log.info("No pong within \(Self.deadThreshold)s — HyperCapslock presumed gone; unholding.")
+            endHold()
+            return
+        }
+        post(Wire.ping)
+    }
+
+    private func post(_ name: Notification.Name) {
+        DistributedNotificationCenter.default().postNotificationName(
+            name, object: nil, userInfo: nil, deliverImmediately: true)
+    }
+
+    /// Monotonic clock — unaffected by wall-clock jumps.
+    private static func now() -> TimeInterval { ProcessInfo.processInfo.systemUptime }
+}

--- a/AnyDrag/Sources/Preferences.swift
+++ b/AnyDrag/Sources/Preferences.swift
@@ -133,7 +133,9 @@ enum Preferences {
         // Empty is a valid persisted state (means "AnyDrag off"), so only the
         // first-launch path falls back to .option.
         if let raw = d.object(forKey: Key.modifierFlags) as? UInt {
-            engine.modifiers = ModifierCombination(rawValue: raw)
+            // Normalize so a stale "Hyper + flags" value (possible before the
+            // exclusivity rule) loads as a clean Hyper-only selection.
+            engine.modifiers = ModifierCombination(rawValue: raw).hyperNormalized
         } else {
             engine.modifiers = .option
         }

--- a/AnyDrag/Sources/Preferences.swift
+++ b/AnyDrag/Sources/Preferences.swift
@@ -13,6 +13,9 @@ enum Preferences {
         static let cornerBracketEnabled = "AnyDragCornerBracketEnabled"
         static let multiDisplayBentoEnabled = "AnyDragMultiDisplayBentoEnabled"
         static let middleAction    = "AnyDragMiddleAction"
+        // Note: the "Hyper" (CapsLock-via-HyperCapslock) modifier needs no key of
+        // its own — it's a bit in `modifierFlags`, so it persists with the rest of
+        // the modifier combination and drives the CapsLock source via didSet.
 
         // Diagnostics — persisted across launches now that the section is
         // always visible in Settings.

--- a/AnyDrag/Sources/Settings/AdvancedPaneViewController.swift
+++ b/AnyDrag/Sources/Settings/AdvancedPaneViewController.swift
@@ -9,6 +9,9 @@ final class AdvancedPaneViewController: NSViewController {
 
     private let modifierChipRow = ModifierChipRow(initial: ModifierCombination())
     private let modifierPreview = NSTextField(labelWithString: "")
+    /// Shown only when the virtual "Hyper" chip is selected — explains it needs
+    /// HyperCapslock running with its broadcast setting on.
+    private let hyperHint = NSTextField(wrappingLabelWithString: "")
 
     private let dragSwitch     = NSSwitch()
     private let maximizeSwitch = NSSwitch()
@@ -67,10 +70,17 @@ final class AdvancedPaneViewController: NSViewController {
         modifierPreview.font = .systemFont(ofSize: 11)
         modifierPreview.textColor = .secondaryLabelColor
 
+        hyperHint.font = .systemFont(ofSize: 11)
+        hyperHint.textColor = .secondaryLabelColor
+        hyperHint.lineBreakMode = .byWordWrapping
+        hyperHint.maximumNumberOfLines = 0
+        hyperHint.stringValue = NSLocalizedString("modifier.hyper.hint", comment: "")
+
         let modifierBlock = NSStackView(views: [
             SettingsRowBuilder.subLabel(NSLocalizedString("Modifier Keys", comment: "")),
             modifierChipRow,
             modifierPreview,
+            hyperHint,
         ])
         modifierBlock.orientation = .vertical
         modifierBlock.alignment = .leading
@@ -187,6 +197,7 @@ final class AdvancedPaneViewController: NSViewController {
             let format = NSLocalizedString("modifier.preview.format", comment: "")
             modifierPreview.stringValue = String(format: format, combo.symbol, combo.displayName)
         }
+        hyperHint.isHidden = !combo.contains(.hyper)
     }
 
     /// When no modifier is selected, AnyDrag has nothing to listen for, so the

--- a/AnyDrag/Sources/Settings/ModifierChipRow.swift
+++ b/AnyDrag/Sources/Settings/ModifierChipRow.swift
@@ -71,6 +71,14 @@ final class ModifierChipRow: NSView {
             proposed.remove(element)
         } else {
             proposed.insert(element)
+            // Hyper is exclusive with the real flag modifiers. The engine arms on
+            // EITHER a held CapsLock (Hyper) OR a flag combination, never a mix —
+            // so selecting one side clears the other to keep the UI honest.
+            if element == .hyper {
+                proposed = .hyper
+            } else {
+                proposed.remove(.hyper)
+            }
         }
         let accepted = onChange?(proposed) ?? false
         if accepted {

--- a/AnyDrag/Sources/Settings/ModifierChipRow.swift
+++ b/AnyDrag/Sources/Settings/ModifierChipRow.swift
@@ -27,6 +27,9 @@ final class ModifierChipRow: NSView {
         Spec(element: .option,  glyph: "⌥",  title: NSLocalizedString("Option", comment: "")),
         Spec(element: .shift,   glyph: "⇧",  title: NSLocalizedString("Shift", comment: "")),
         Spec(element: .command, glyph: "⌘",  title: NSLocalizedString("Command", comment: "")),
+        // Virtual "Hyper" = hold CapsLock via HyperCapslock. Same chip style; a
+        // short word rather than a glyph, like "fn".
+        Spec(element: .hyper,   glyph: NSLocalizedString("Hyper", comment: ""), title: NSLocalizedString("Hyper", comment: "")),
     ]
     private var chips: [ModifierChip] = []
 


### PR DESCRIPTION
Adds a virtual **Hyper** modifier: hold CapsLock (signalled by HyperCapslock over `DistributedNotificationCenter`) to arm AnyDrag's gestures, without CapsLock being a real event flag.

- **`ModifierCombination.hyper`** (1<<5, no `CGEventFlag`) + a 6th "Hyper" chip in the modifier row, with a hint explaining it needs HyperCapslock.
- **`HyperCapslockCapsHoldSource`** — the only AnyDrag file aware of the wire protocol. Owns the cross-process listening plus a 100 ms-ping / 1 s-timeout liveness watchdog, so AnyDrag disarms within ~1 s if HyperCapslock is killed mid-hold.
- Hyper is **mutually exclusive** with the flag chips (selecting one clears the other), and `hyperNormalized` sanitizes any stale persisted 'Hyper + flags' value on load.

Pairs with HyperCapslock's #13.