### PR TITLE
fix: keep tiling overlay within screen bounds

### DIFF
--- a/AnyDrag/Sources/BentoCursorTransition.swift
+++ b/AnyDrag/Sources/BentoCursorTransition.swift
@@ -1,0 +1,126 @@
+import AppKit
+
+/// Hides an instantaneous cursor warp behind a short visual glide. The real
+/// cursor is moved to the bento's cancel center immediately so gesture math is
+/// correct; a mouse-transparent cursor image animates there from the press
+/// point before the system cursor is revealed again.
+final class BentoCursorTransition {
+
+    private static let duration: TimeInterval = 0.10
+
+    private let panel: NSPanel
+    private let imageView = NSImageView()
+    private var cursorHidden = false
+    private var generation = 0
+    private var startPoint: NSPoint?
+    private var endPoint: NSPoint?
+    private var suppressMotionUntil: TimeInterval = 0
+
+    private(set) var isActive = false
+
+    init() {
+        panel = NSPanel(
+            contentRect: .zero,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: true
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false
+        panel.ignoresMouseEvents = true
+        panel.level = .screenSaver
+        panel.animationBehavior = .none
+        panel.hidesOnDeactivate = false
+        panel.isMovable = false
+        panel.isReleasedWhenClosed = false
+        imageView.imageScaling = .scaleNone
+        panel.contentView = imageView
+    }
+
+    deinit {
+        if cursorHidden {
+            CGDisplayShowCursor(CGMainDisplayID())
+        }
+    }
+
+    func move(from startNS: NSPoint, to endNS: NSPoint) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        finishImmediately()
+
+        let distance = hypot(endNS.x - startNS.x, endNS.y - startNS.y)
+        guard distance >= 1, let primary = NSScreen.screens.first else { return }
+
+        let cursor = NSCursor.current
+        let image = cursor.image
+        let hotSpot = cursor.hotSpot
+        imageView.image = image
+        imageView.frame = NSRect(origin: .zero, size: image.size)
+        panel.setContentSize(image.size)
+
+        let origin: (NSPoint) -> NSPoint = { point in
+            NSPoint(
+                x: point.x - hotSpot.x,
+                y: point.y - (image.size.height - hotSpot.y)
+            )
+        }
+        panel.setFrameOrigin(origin(startNS))
+        panel.orderFrontRegardless()
+
+        startPoint = startNS
+        endPoint = endNS
+        suppressMotionUntil = ProcessInfo.processInfo.systemUptime + 0.05
+        isActive = true
+        cursorHidden = CGDisplayHideCursor(CGMainDisplayID()) == .success
+        let targetCG = CGPoint(x: endNS.x, y: primary.frame.height - endNS.y)
+        guard CGWarpMouseCursorPosition(targetCG) == .success else {
+            finishImmediately()
+            return
+        }
+
+        generation &+= 1
+        let currentGeneration = generation
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = Self.duration
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            panel.animator().setFrameOrigin(origin(endNS))
+        } completionHandler: { [weak self] in
+            guard let self, self.generation == currentGeneration else { return }
+            self.finishImmediately()
+        }
+    }
+
+    /// Called on the first real drag event so user input always wins over the
+    /// cosmetic transition and the system cursor becomes visible immediately.
+    func finishImmediately() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        generation &+= 1
+        isActive = false
+        startPoint = nil
+        endPoint = nil
+        suppressMotionUntil = 0
+        panel.orderOut(nil)
+        if cursorHidden {
+            CGDisplayShowCursor(CGMainDisplayID())
+            cursorHidden = false
+        }
+    }
+
+    /// Suppress queued events at the pre-warp and post-warp locations. A point
+    /// elsewhere is real user movement, which cancels the cosmetic transition
+    /// and should proceed through normal tile resolution.
+    func shouldSuppressMotion(at point: NSPoint) -> Bool {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard isActive, let startPoint, let endPoint else { return false }
+        if ProcessInfo.processInfo.systemUptime < suppressMotionUntil {
+            return true
+        }
+        let nearStart = hypot(point.x - startPoint.x, point.y - startPoint.y) <= 2
+        let nearEnd = hypot(point.x - endPoint.x, point.y - endPoint.y) <= 2
+        if nearStart || nearEnd {
+            return true
+        }
+        finishImmediately()
+        return false
+    }
+}

--- a/AnyDrag/Sources/TileCancelDot.swift
+++ b/AnyDrag/Sources/TileCancelDot.swift
@@ -22,6 +22,12 @@ import AppKit
 
 final class TileCancelDot: NSPanel {
 
+    private struct PanelPlacement {
+        let windowFrame: NSRect
+        let layoutOrigin: NSPoint
+        let displayOffset: NSPoint
+    }
+
     // MARK: - Layout constants (single-display)
 
     /// Panel size in points. ~16:10 ratio so the tile previews read as
@@ -29,6 +35,9 @@ final class TileCancelDot: NSPanel {
     /// small enough not to swallow the underlying window.
     static let panelWidth: CGFloat = 290
     static let panelHeight: CGFloat = 185
+
+    /// Room for the shadow and, when displaced, the popover pointer.
+    private static let screenInset: CGFloat = 12
 
     /// Padding between the panel chrome and the grid of tiles.
     static let chromePadding: CGFloat = 12
@@ -79,19 +88,20 @@ final class TileCancelDot: NSPanel {
     /// path — pixel-identical to the pre-multi-display behaviour.
     var multiDisplayEnabled: Bool = false
 
-    /// NS origin of the IDEAL (un-clipped) multi-display panel rect.
-    /// Tracked separately from `self.frame.origin` because the actual
-    /// window frame is clipped to the current display's visibleFrame —
-    /// the view draws and `resolve(...)` hit-tests in the un-clipped
-    /// coord space so the cursor's relationship to each card cell stays
-    /// honest even when the window is smaller than the layout.
-    fileprivate var idealPanelOriginNS: NSPoint?
+    /// Origin used by the current layout's hit testing. It differs from the
+    /// window origin only when an oversized multi-display layout is clipped.
+    fileprivate var layoutOriginNS: NSPoint?
+
+    /// The immutable middle-button press point. Single-display direction
+    /// selection stays relative to this point even when the panel moves.
+    private var gestureOriginNS: NSPoint?
 
     // MARK: - Subviews
 
     private let contentContainer = NSView()
     private let vibrancyView = BentoPopoverEffectView()
     private let fillView = TileCancelDotView()
+    private let cursorTransition = BentoCursorTransition()
 
     /// Plan B "floating chip": the target app's icon + name, hovering just
     /// above the bento. A separate panel (not part of this one) so the grid
@@ -191,25 +201,31 @@ final class TileCancelDot: NSPanel {
     private func showSingleDisplay(atCGPoint cgScreenPoint: CGPoint) {
         guard let primary = NSScreen.screens.first else { return }
         let nsY = primary.frame.height - cgScreenPoint.y
+        let clickNS = NSPoint(x: cgScreenPoint.x, y: nsY)
+        let currentScreen = NSScreen.screens.first(where: { $0.frame.contains(clickNS) }) ?? primary
 
-        let frame = NSRect(
+        let idealFrame = NSRect(
             x: cgScreenPoint.x - Self.panelWidth / 2,
             y: nsY - Self.panelHeight / 2,
             width: Self.panelWidth,
             height: Self.panelHeight
         )
-        setFrame(frame, display: true)
+        let placement = Self.placePanel(idealFrame: idealFrame, visibleFrame: currentScreen.visibleFrame)
+        let cancelCenter = NSPoint(x: placement.windowFrame.midX, y: placement.windowFrame.midY)
+        gestureOriginNS = cancelCenter
+        layoutOriginNS = placement.layoutOrigin
+        setFrame(placement.windowFrame, display: true)
         fillView.displayLayout = nil
         fillView.currentScreen = nil
         fillView.activeScreen = nil
         fillView.activeZone = nil
-        fillView.displayOffset = .zero
-        idealPanelOriginNS = nil
+        fillView.displayOffset = placement.displayOffset
         fillView.needsDisplay = true
         if !isVisible {
             orderFrontRegardless()
         }
-        positionTargetChip(panelFrame: frame)
+        cursorTransition.move(from: clickNS, to: cancelCenter)
+        positionTargetChip(panelFrame: placement.windowFrame)
     }
 
     private func showMultiDisplay(atCGPoint cgScreenPoint: CGPoint) {
@@ -239,41 +255,25 @@ final class TileCancelDot: NSPanel {
             height: result.panelSize.height
         )
 
-        // Clip the WINDOW frame to the current display's visibleFrame
-        // (intersection). Anything outside becomes a region we just
-        // won't have a window for — the view inside the window draws
-        // every card at its *ideal* panel-local position, so cards
-        // whose position falls outside the (smaller) window are
-        // naturally clipped by the view bounds and never appear. This
-        // preserves "cancel cell sits exactly on the cursor" without
-        // needing the panel to straddle two displays (which macOS won't
-        // do with "Displays have separate Spaces" on).
-        let visible = currentScreen.visibleFrame
-        let clippedFrame = idealFrame.intersection(visible)
-        // Defensive: if the click somehow doesn't put the current card
-        // on the current display, fall back to the ideal frame.
-        let windowFrame = clippedFrame.isEmpty ? idealFrame : clippedFrame
-
-        // How much of the ideal panel's bottom-left got cut. View-local
-        // (0,0) corresponds to ideal panel-local `displayOffset`, so
-        // every card's view-local position = panel-local − displayOffset.
-        let displayOffset = NSPoint(
-            x: windowFrame.minX - idealFrame.minX,
-            y: windowFrame.minY - idealFrame.minY
+        let placement = Self.placePanel(idealFrame: idealFrame, visibleFrame: currentScreen.visibleFrame)
+        let cancelCenter = NSPoint(
+            x: placement.layoutOrigin.x + anchorCenter.x,
+            y: placement.layoutOrigin.y + anchorCenter.y
         )
-
-        idealPanelOriginNS = idealFrame.origin
-        setFrame(windowFrame, display: true)
+        gestureOriginNS = cancelCenter
+        layoutOriginNS = placement.layoutOrigin
+        setFrame(placement.windowFrame, display: true)
         fillView.displayLayout = result.cards
         fillView.currentScreen = currentScreen
         fillView.activeScreen = nil
         fillView.activeZone = nil
-        fillView.displayOffset = displayOffset
+        fillView.displayOffset = placement.displayOffset
         fillView.needsDisplay = true
         if !isVisible {
             orderFrontRegardless()
         }
-        positionTargetChip(panelFrame: windowFrame)
+        cursorTransition.move(from: clickNS, to: cancelCenter)
+        positionTargetChip(panelFrame: placement.windowFrame)
     }
 
     func hide() {
@@ -281,6 +281,9 @@ final class TileCancelDot: NSPanel {
             orderOut(nil)
         }
         targetChip.hide()
+        cursorTransition.finishImmediately()
+        gestureOriginNS = nil
+        layoutOriginNS = nil
         // Drop the target so a stray show() without a fresh setTarget(...)
         // can't surface the previous gesture's app name/icon.
         targetAppName = nil
@@ -289,6 +292,49 @@ final class TileCancelDot: NSPanel {
 
     override var canBecomeKey: Bool { false }
     override var canBecomeMain: Bool { false }
+
+    // MARK: - Edge-safe placement
+
+    private static func placePanel(idealFrame: NSRect, visibleFrame: NSRect) -> PanelPlacement {
+        let insetVisible = visibleFrame.insetBy(dx: screenInset, dy: screenInset)
+        let available = insetVisible.width > 0 && insetVisible.height > 0
+            ? insetVisible
+            : visibleFrame
+
+        let x = placeAxis(idealMin: idealFrame.minX, size: idealFrame.width,
+                          availableMin: available.minX, availableMax: available.maxX)
+        let y = placeAxis(idealMin: idealFrame.minY, size: idealFrame.height,
+                          availableMin: available.minY, availableMax: available.maxY)
+
+        return PanelPlacement(
+            windowFrame: NSRect(x: x.windowMin, y: y.windowMin,
+                                width: x.windowSize, height: y.windowSize),
+            layoutOrigin: NSPoint(x: x.layoutMin, y: y.layoutMin),
+            displayOffset: NSPoint(x: x.windowMin - x.layoutMin,
+                                   y: y.windowMin - y.layoutMin)
+        )
+    }
+
+    private static func placeAxis(
+        idealMin: CGFloat,
+        size: CGFloat,
+        availableMin: CGFloat,
+        availableMax: CGFloat
+    ) -> (windowMin: CGFloat, windowSize: CGFloat, layoutMin: CGFloat) {
+        let availableSize = availableMax - availableMin
+        if size <= availableSize {
+            let placedMin = max(availableMin, min(idealMin, availableMax - size))
+            return (placedMin, size, placedMin)
+        }
+
+        let idealMax = idealMin + size
+        let clippedMin = max(idealMin, availableMin)
+        let clippedMax = min(idealMax, availableMax)
+        guard clippedMax > clippedMin else {
+            return (availableMin, availableSize, idealMin)
+        }
+        return (clippedMin, clippedMax - clippedMin, idealMin)
+    }
 
     // MARK: - Layout computation (multi-display)
 
@@ -384,6 +430,9 @@ final class TileCancelDot: NSPanel {
         guard let primary = NSScreen.screens.first else { return nil }
         let nsY = primary.frame.height - cgPoint.y
         let cursorNS = NSPoint(x: cgPoint.x, y: nsY)
+        if cursorTransition.shouldSuppressMotion(at: cursorNS) {
+            return nil
+        }
 
         if let layout = fillView.displayLayout {
             // Multi-display: hit-test in the IDEAL panel coord space so
@@ -393,14 +442,14 @@ final class TileCancelDot: NSPanel {
             // correctly. The window's frame is a clipped subset of the
             // ideal — cardRects are stored in ideal panel-local coords,
             // and so is `cursorLocal` here.
-            let originNS = idealPanelOriginNS ?? self.frame.origin
+            let originNS = layoutOriginNS ?? self.frame.origin
             let local = NSPoint(
                 x: cursorNS.x - originNS.x,
                 y: cursorNS.y - originNS.y
             )
             return Self.resolveMultiDisplay(cursorLocal: local, layout: layout)
         } else {
-            return resolveSingleDisplay(cursorNS: cursorNS, panelFrame: self.frame)
+            return resolveSingleDisplay(cursorNS: cursorNS)
         }
     }
 
@@ -432,15 +481,15 @@ final class TileCancelDot: NSPanel {
     }
 
     private func resolveSingleDisplay(
-        cursorNS: NSPoint,
-        panelFrame: NSRect
+        cursorNS: NSPoint
     ) -> (screen: NSScreen, zone: TileZone)? {
         // Single-display: the cells extend to infinity, so resolve from
         // the panel-relative offset and look up which screen the cursor
         // is currently on (since the tile target follows the cursor's
         // display, not a specific panel-local one).
-        let dx = cursorNS.x - panelFrame.midX
-        let dy = panelFrame.midY - cursorNS.y  // flip to y-down for the existing math
+        let origin = gestureOriginNS ?? NSPoint(x: frame.midX, y: frame.midY)
+        let dx = cursorNS.x - origin.x
+        let dy = origin.y - cursorNS.y  // flip to y-down for the existing math
         let zone = TileZone.bentoZone(
             forDx: dx, dy: dy,
             halfDeadzoneWidth: Self.halfDeadzoneWidth,


### PR DESCRIPTION
## Summary

- constrain the middle-click tiling overlay to the active display visible frame
- smoothly move the cursor to the cancel-cell center when edge avoidance displaces the overlay
- suppress queued pre/post-warp drag events so tile highlights do not flash during the transition
- preserve the original press point for plain middle-click replay and retain oversized multi-display clipping

## Testing

- manually verified edge and corner placement on macOS
- verified the cursor transition and cancel-cell alignment
- `xcodegen generate`
- `xcodebuild -project AnyDrag.xcodeproj -scheme AnyDrag -configuration Debug CODE_SIGNING_ALLOWED=NO build`