### PR TITLE
fix: prevent input freeze after Accessibility permission revocation

### DIFF
--- a/AnyDrag/Sources/DragEngine.swift
+++ b/AnyDrag/Sources/DragEngine.swift
@@ -431,6 +431,11 @@ final class DragEngine {
     /// freezing system-wide clicks.
     private var trustRestoreDebounceTasks: [DispatchWorkItem] = []
     private var backstopTimer: Timer?
+    /// `AXIsProcessTrusted()` can stay pinned to true for the lifetime of a
+    /// process after a live revoke. Once WindowServer disables our tap by user
+    /// input, never recreate it in this process; relaunch is the only reliable
+    /// way to obtain a fresh TCC decision.
+    private var trustRevokedUntilRelaunch = false
 
     /// Wall-clock anchor for the backstop's events-per-second log. Only
     /// touched on main, so no lock needed.
@@ -715,6 +720,10 @@ final class DragEngine {
     /// Safe to call repeatedly — no-op when the cached state already matches.
     private func applyTrustChange(_ trusted: Bool, source: String) {
         dispatchPrecondition(condition: .onQueue(.main))
+        if trusted && trustRevokedUntilRelaunch {
+            Self.log.warn("Ignoring stale AX trusted=true after live revoke [\(source)]; relaunch required")
+            return
+        }
         let previous = cbState.withLock { state -> Bool in
             let p = state.trusted
             state.trusted = trusted
@@ -837,36 +846,34 @@ final class DragEngine {
             return Unmanaged.passUnretained(event)
         }
 
-        // Tap disabled by the system (callback ran too long, or AX was
-        // revoked). Decide on main where we can probe and access the
-        // tap reference race-free.
+        // User-input disable is the revoke signal. Fail open immediately and
+        // latch the engine off until relaunch: TCC can keep reporting a stale
+        // `true` for this process, and re-enabling that unauthorized default
+        // tap freezes system-wide clicks. Timeout disables are recoverable and
+        // may still use the trust query before re-enabling.
         if type == .tapDisabledByUserInput || type == .tapDisabledByTimeout {
-            Self.log.info("tap-disabled event \(type) — dispatching trust check to main")
+            Self.log.info("tap-disabled event \(type) — dispatching recovery to main")
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
-                // We're here because the OS just killed our tap. The tap
-                // can only exist if we were previously trusted, so this
-                // is unambiguously a revoke-direction check — consult
-                // `AXIsProcessTrusted()` directly. The listen-only mouse
-                // probe used here previously *lied on revoke* (succeeded
-                // because WindowServer pins per-process trust at launch),
-                // which made us re-enable an unauthorized `.defaultTap`
-                // at the head of the event chain and freeze all clicks
-                // system-wide. TCC has had plenty of time to settle by
-                // the time we receive a tap-disabled event, so the bare
-                // `AXIsProcessTrusted()` read is the right oracle here.
+                if type == .tapDisabledByUserInput {
+                    self.trustRevokedUntilRelaunch = true
+                    Self.log.warn("tap disabled by user input — stopping until relaunch")
+                    self.applyTrustChange(false, source: "tap-disabled-by-user-input")
+                    return
+                }
+
                 let trusted = AXIsProcessTrusted()
-                Self.log.info("tap-disabled trust check: AXIsProcessTrusted=\(trusted)")
+                Self.log.info("tap-timeout trust check: AXIsProcessTrusted=\(trusted)")
                 if trusted {
                     self.cbState.withLock { state in
                         if let tap = state.tap {
                             CGEvent.tapEnable(tap: tap, enable: true)
-                            Self.log.info("Re-enabled tap (still authorized)")
+                            Self.log.info("Re-enabled tap after timeout")
                         }
                     }
                 } else {
-                    Self.log.warn("tap-disabled and AX revoked — calling applyTrustChange(false)")
-                    self.applyTrustChange(false, source: "tap-disabled")
+                    Self.log.warn("tap timed out and AX is revoked — stopping")
+                    self.applyTrustChange(false, source: "tap-disabled-by-timeout")
                 }
             }
             // The tap missed events while disabled — any in-flight tile

--- a/AnyDrag/Sources/DragEngine.swift
+++ b/AnyDrag/Sources/DragEngine.swift
@@ -738,7 +738,9 @@ final class DragEngine {
         if trusted {
             start()
         } else {
+            trustRevokedUntilRelaunch = true
             stop()
+            PermissionManager.relaunchForAccessibilityAuthorization()
         }
     }
 
@@ -846,35 +848,21 @@ final class DragEngine {
             return Unmanaged.passUnretained(event)
         }
 
-        // User-input disable is the revoke signal. Fail open immediately and
-        // latch the engine off until relaunch: TCC can keep reporting a stale
-        // `true` for this process, and re-enabling that unauthorized default
-        // tap freezes system-wide clicks. Timeout disables are recoverable and
-        // may still use the trust query before re-enabling.
+        // macOS reports a live AX revoke as `tapDisabledByTimeout` (-2), not
+        // consistently as `tapDisabledByUserInput` (-1). TCC can then keep
+        // reporting stale `true` for this process, so neither event is safe to
+        // re-enable. Fail open synchronously, then tear down on main and require
+        // a relaunch for a fresh trust decision.
         if type == .tapDisabledByUserInput || type == .tapDisabledByTimeout {
-            Self.log.info("tap-disabled event \(type) — dispatching recovery to main")
+            Self.log.warn("tap-disabled event \(type) — disabling immediately until relaunch")
+            cbState.withLock { state in
+                if let tap = state.tap {
+                    CGEvent.tapEnable(tap: tap, enable: false)
+                }
+            }
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
-                if type == .tapDisabledByUserInput {
-                    self.trustRevokedUntilRelaunch = true
-                    Self.log.warn("tap disabled by user input — stopping until relaunch")
-                    self.applyTrustChange(false, source: "tap-disabled-by-user-input")
-                    return
-                }
-
-                let trusted = AXIsProcessTrusted()
-                Self.log.info("tap-timeout trust check: AXIsProcessTrusted=\(trusted)")
-                if trusted {
-                    self.cbState.withLock { state in
-                        if let tap = state.tap {
-                            CGEvent.tapEnable(tap: tap, enable: true)
-                            Self.log.info("Re-enabled tap after timeout")
-                        }
-                    }
-                } else {
-                    Self.log.warn("tap timed out and AX is revoked — stopping")
-                    self.applyTrustChange(false, source: "tap-disabled-by-timeout")
-                }
+                self.applyTrustChange(false, source: "tap-disabled")
             }
             // The tap missed events while disabled — any in-flight tile
             // gesture is now stranded. Drop it so we don't apply a stale

--- a/AnyDrag/Sources/PermissionManager.swift
+++ b/AnyDrag/Sources/PermissionManager.swift
@@ -13,7 +13,7 @@ final class PermissionManager {
             return
         }
 
-        showPermissionAlert()
+        requestAccessibilityAuthorization()
 
         Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] timer in
             guard let self else { timer.invalidate(); return }
@@ -26,32 +26,45 @@ final class PermissionManager {
 
     // MARK: - Private
 
-    private func showPermissionAlert() {
-        let alert = NSAlert()
-        alert.messageText = NSLocalizedString("permission.title", comment: "")
-        alert.informativeText = NSLocalizedString("permission.message", comment: "")
-        alert.alertStyle = .warning
-        alert.addButton(withTitle: NSLocalizedString("permission.openSettings", comment: ""))
-        alert.addButton(withTitle: NSLocalizedString("permission.quit", comment: ""))
-
-        let response = alert.runModal()
-        if response == .alertFirstButtonReturn {
-            openAccessibilitySettings()
-        } else {
-            NSApp.terminate(nil)
-        }
-    }
-
-    private func openAccessibilitySettings() {
-        Self.openAccessibilitySettings()
+    /// Ask TCC to register AnyDrag and present the native Accessibility
+    /// authorization prompt. A fresh process is required after a live revoke
+    /// because the old process may retain a stale positive trust result.
+    private func requestAccessibilityAuthorization() {
+        let options = [
+            kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true,
+        ] as CFDictionary
+        _ = AXIsProcessTrustedWithOptions(options)
     }
 
     /// Open System Settings → Privacy & Security → Accessibility. Shared by
-    /// the launch-time permission alert and the in-app permission row.
+    /// the native permission prompt and the in-app permission row.
     static func openAccessibilitySettings() {
         if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
             NSWorkspace.shared.open(url)
         }
+    }
+
+    /// Relaunch after a live revoke so TCC evaluates authorization in a fresh
+    /// process. The new instance runs `ensurePermissions`, which presents the
+    /// single native prompt and re-registers an app removed from the list.
+    static func relaunchForAccessibilityAuthorization() {
+#if DEBUG
+        // A relaunched process is detached from Xcode's debugger. During local
+        // development, exit cleanly and let the developer run again instead.
+        NSApp.terminate(nil)
+#else
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.activates = true
+        configuration.createsNewApplicationInstance = true
+        NSWorkspace.shared.openApplication(
+            at: Bundle.main.bundleURL,
+            configuration: configuration
+        ) { _, _ in
+            DispatchQueue.main.async {
+                NSApp.terminate(nil)
+            }
+        }
+#endif
     }
 
     // MARK: - Trust oracle


### PR DESCRIPTION
## Summary

Prevent AnyDrag from freezing system-wide mouse input when Accessibility permission is revoked while the app is running, and make reauthorization work both when the permission toggle is disabled and when AnyDrag is removed from the Accessibility list.

## User-visible failures

Several related behaviors were observed while testing live permission revocation:

1. Revoking Accessibility while AnyDrag was running could make the whole desktop stop accepting mouse clicks. Keyboard input sometimes recovered after the event-tap timeout, but clicks remained unreliable.
2. Disabling the Accessibility toggle and removing the app from the list did not always follow the same detection path. One path stopped the drag engine without presenting reauthorization UI.
3. Opening the Accessibility settings pane alone did not add AnyDrag back after it had been removed, leaving the user to add it manually.
4. Combining the existing custom permission alert with the native TCC prompt produced two authorization windows.
5. Automatically relaunching a Debug build created a standalone AnyDrag process detached from Xcode, so stopping the Xcode session did not stop the relaunched app.

## Root cause

AnyDrag installs a mutable `.defaultTap`, so an invalid tap at the head of the event chain can affect input system-wide.

The previous recovery logic assumed a live Accessibility revoke would arrive as `tapDisabledByUserInput` (`-1`) and treated `tapDisabledByTimeout` (`-2`) as recoverable. On the tested macOS version, revocation was actually reported as `tapDisabledByTimeout`. `AXIsProcessTrusted()` could still return a stale `true` for the lifetime of that process, so the code re-enabled an unauthorized event tap. That tap then interfered with global click delivery.

There is also a race between the event-tap callback and the distributed Accessibility notification. If the notification observed `true -> false` first, the engine stopped but the tap-specific reauthorization path never ran.

Finally, navigating to System Settings only opens the pane. It does not re-register an application removed from the Accessibility list. A fresh process must call `AXIsProcessTrustedWithOptions` with `kAXTrustedCheckOptionPrompt` so TCC can register the app and present the native authorization flow.

## Changes

- Treat both tap-disabled event types as unsafe after a possible live revoke.
- Disable the event tap synchronously inside the callback before returning the current event unchanged.
- Tear the tap down on the main thread and latch the engine off for the remainder of that process.
- Centralize runtime revoke recovery on every real `true -> false` trust transition, regardless of whether the tap callback or distributed notification wins the race.
- Replace the custom startup permission alert with the native Accessibility prompt, avoiding duplicate authorization windows.
- Relaunch the Release build after runtime revocation so TCC evaluates permission in a fresh process and can add a removed app back to the list.
- Exit cleanly without relaunching in Debug builds, allowing the developer to use `Cmd+R` again without leaving an AnyDrag instance detached from Xcode.

## Resulting behavior

### Release

1. The event tap fails open immediately when permission is revoked, so other applications continue receiving clicks.
2. AnyDrag starts a fresh instance and exits the stale process.
3. The new process displays the single native macOS Accessibility prompt.
4. Opening System Settings from that prompt shows AnyDrag in the Accessibility list, including after the prior entry was removed.

### Debug

1. The event tap fails open and is torn down.
2. AnyDrag exits without launching a detached replacement process.
3. Running again with `Cmd+R` starts a fresh process and displays the native prompt.

## Verification

- Reproduced the original failure and confirmed macOS logged `tapDisabledByTimeout` (`-2`) followed by the old `Re-enabled tap after timeout` path.
- Confirmed the updated path disables the tap immediately and tears it down without re-enabling it.
- Tested permission removal without losing global mouse clicks.
- Built both Debug and Release successfully with signing disabled.

Existing Swift 6 `Sendable` diagnostics remain warnings and are unrelated to this change.
