### PR TITLE
fix: defer cross-screen tiling size on macOS 27

### DIFF
--- a/AnyDrag/Sources/DragEngine.swift
+++ b/AnyDrag/Sources/DragEngine.swift
@@ -245,6 +245,10 @@ final class DragEngine {
     // reveals the tile cancel dot. 5 pt is enough to tell an intentional drag
     // from the jitter of a plain middle-click. Stored squared to skip the sqrt.
     private static let tileDragRevealThresholdSquared: CGFloat = 25
+    private static let crossScreenTileSettleDelay: TimeInterval = 0.1
+    private static var needsDeferredCrossScreenTileSizing: Bool {
+        ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 27
+    }
 
     private static let log = FileLog("DragEngine")
 
@@ -1447,15 +1451,16 @@ final class DragEngine {
         if let finish = tileFinish {
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
-                self.tileOverlay.hide()
                 self.tileCancelDot.hide()
                 if let zone = finish.zone, let screen = finish.targetScreen {
                     self.applyTile(zone: zone, target: finish.target, screen: screen)
                 } else if finish.sawDirection {
+                    self.tileOverlay.hide()
                     // User actively chose a direction and then moved back into
                     // the cancel cell — clean cancel, don't replay the click.
                     Self.log.info("tile gesture cancelled by user (returned to deadzone)")
                 } else {
+                    self.tileOverlay.hide()
                     // Cursor never left the center cell — treat as a plain
                     // middle-click so apps still see it (browser tab close, etc.).
                     self.replayMiddleClick(at: finish.origin)
@@ -1504,10 +1509,14 @@ final class DragEngine {
     private func applyTile(zone: TileZone,
                            target: (pid: pid_t, windowID: CGWindowID, frame: CGRect, app: String),
                            screen: NSScreen) {
-        guard axGuardOrAbort("applyTile") else { return }
+        guard axGuardOrAbort("applyTile") else {
+            tileOverlay.hide()
+            return
+        }
         Analytics.trackTile(tile: zone.analyticsKey, trigger: .middleDirection)
         guard let axWindow = findAXWindow(pid: target.pid, windowFrame: target.frame) else {
             Self.log.warn("applyTile: findAXWindow returned nil for pid=\(target.pid) wid=\(target.windowID)")
+            tileOverlay.hide()
             return
         }
         Self.log.info("tile commit: app=\"\(target.app)\" wid=\(target.windowID) zone=\(zone)")
@@ -1519,7 +1528,77 @@ final class DragEngine {
         let currentFrame = getWindowFrame(axWindow) ?? target.frame
         savedFrames[target.windowID] = currentFrame
 
-        setWindowFrame(axWindow, frame: cgRect)
+        let sourceCenter = CGPoint(x: currentFrame.midX, y: currentFrame.midY)
+        let destinationCenter = CGPoint(x: cgRect.midX, y: cgRect.midY)
+        let sourceScreen = self.screen(containingCGPoint: sourceCenter)
+        let destinationScreen = self.screen(containingCGPoint: destinationCenter)
+        if let sourceScreen,
+           let destinationScreen,
+           sourceScreen.frame != destinationScreen.frame,
+           Self.needsDeferredCrossScreenTileSizing {
+            setCrossScreenTileFrame(
+                axWindow,
+                frame: cgRect,
+                destinationScreenFrame: destinationScreen.frame,
+                target: target,
+                zone: zone
+            )
+        } else {
+            setWindowFrame(axWindow, frame: cgRect)
+            tileOverlay.hide()
+        }
+    }
+
+    /// macOS 27 updates a moved AX window's display assignment asynchronously.
+    /// Keep the preview visible while moving at the current size, then apply
+    /// the final size after WindowServer recognizes the destination display.
+    private func setCrossScreenTileFrame(
+        _ axWindow: AXUIElement,
+        frame targetFrame: CGRect,
+        destinationScreenFrame: NSRect,
+        target: (pid: pid_t, windowID: CGWindowID, frame: CGRect, app: String),
+        zone: TileZone
+    ) {
+        var targetPosition = targetFrame.origin
+        withEnhancedUIDisabled(for: axWindow) {
+            if let value = AXValueCreate(.cgPoint, &targetPosition) {
+                AXUIElementSetAttributeValue(axWindow, kAXPositionAttribute as CFString, value)
+            }
+        }
+
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Self.crossScreenTileSettleDelay
+        ) { [weak self] in
+            guard let self else { return }
+            defer { self.tileOverlay.hide() }
+
+            guard let actualFrame = self.getWindowFrame(axWindow) else { return }
+            let actualCenter = CGPoint(x: actualFrame.midX, y: actualFrame.midY)
+            guard let actualScreen = self.screen(containingCGPoint: actualCenter),
+                  actualScreen.frame == destinationScreenFrame
+            else {
+                Self.log.warn(
+                    "cross-screen tile did not reach destination before resize: "
+                        + "app=\"\(target.app)\" wid=\(target.windowID) zone=\(zone)"
+                )
+                return
+            }
+
+            var targetSize = targetFrame.size
+            var finalPosition = targetFrame.origin
+            self.withEnhancedUIDisabled(for: axWindow) {
+                if let value = AXValueCreate(.cgSize, &targetSize) {
+                    AXUIElementSetAttributeValue(axWindow, kAXSizeAttribute as CFString, value)
+                }
+                if let value = AXValueCreate(.cgPoint, &finalPosition) {
+                    AXUIElementSetAttributeValue(axWindow, kAXPositionAttribute as CFString, value)
+                }
+            }
+            Self.log.info(
+                "cross-screen tile finalized after destination assignment: "
+                    + "app=\"\(target.app)\" wid=\(target.windowID) zone=\(zone)"
+            )
+        }
     }
 
     /// Convert an NSScreen-coord rect (bottom-left origin) into a Quartz CG rect (top-left origin).
@@ -1808,8 +1887,30 @@ final class DragEngine {
     }
 
     private func setWindowFrame(_ window: AXUIElement, frame: CGRect) {
-        // Disable AXEnhancedUserInterface if enabled (Electron apps set this,
-        // which causes AX resizing to silently fail). Rectangle does the same.
+        withEnhancedUIDisabled(for: window) {
+            // Size → Position → Size (Rectangle's proven approach).
+            // macOS constrains window size to the current display, so we must:
+            // 1. Shrink first (so the window fits before moving)
+            // 2. Move to the target position
+            // 3. Set size again (in case the display changed and the constraint was wrong)
+            var position = frame.origin
+            var size = frame.size
+            if let sv = AXValueCreate(.cgSize, &size) {
+                AXUIElementSetAttributeValue(window, kAXSizeAttribute as CFString, sv)
+            }
+            if let pv = AXValueCreate(.cgPoint, &position) {
+                AXUIElementSetAttributeValue(window, kAXPositionAttribute as CFString, pv)
+            }
+            if let sv = AXValueCreate(.cgSize, &size) {
+                AXUIElementSetAttributeValue(window, kAXSizeAttribute as CFString, sv)
+            }
+        }
+    }
+
+    /// Electron apps may enable AXEnhancedUserInterface, which can make AX
+    /// position/size writes silently fail. Temporarily disable it around a
+    /// related group of frame mutations, matching Rectangle's behavior.
+    private func withEnhancedUIDisabled(for window: AXUIElement, _ mutation: () -> Void) {
         var pid: pid_t = 0
         AXUIElementGetPid(window, &pid)
         let appElement = AXUIElementCreateApplication(pid)
@@ -1823,22 +1924,7 @@ final class DragEngine {
             AXUIElementSetAttributeValue(appElement, "AXEnhancedUserInterface" as CFString, kCFBooleanFalse)
         }
 
-        // Size → Position → Size (Rectangle's proven approach).
-        // macOS constrains window size to the current display, so we must:
-        // 1. Shrink first (so the window fits before moving)
-        // 2. Move to the target position
-        // 3. Set size again (in case the display changed and the constraint was wrong)
-        var position = frame.origin
-        var size = frame.size
-        if let sv = AXValueCreate(.cgSize, &size) {
-            AXUIElementSetAttributeValue(window, kAXSizeAttribute as CFString, sv)
-        }
-        if let pv = AXValueCreate(.cgPoint, &position) {
-            AXUIElementSetAttributeValue(window, kAXPositionAttribute as CFString, pv)
-        }
-        if let sv = AXValueCreate(.cgSize, &size) {
-            AXUIElementSetAttributeValue(window, kAXSizeAttribute as CFString, sv)
-        }
+        mutation()
 
         if hadEnhancedUI {
             AXUIElementSetAttributeValue(appElement, "AXEnhancedUserInterface" as CFString, kCFBooleanTrue)


### PR DESCRIPTION
## Summary

Fix middle-button direction tiling leaving a large gap at the bottom of a window moved from a smaller built-in display to a larger external display on macOS 27.

The workaround is intentionally limited to cross-display direction tiling on macOS 27 and later. macOS 26 and earlier keep the existing immediate placement behavior.

## Reproduction setup

The issue was reproduced on:

- macOS 27.0, build `26A5378n`
- Studio Display on the left, configured as the main display
- Built-in MacBook display on the right
- Dock positioned on the left with auto-hide enabled

Observed logical screen geometry:

| Display | Frame | Visible frame |
| --- | --- | --- |
| Studio Display | `2560 x 1440` | `2560 x 1410` |
| Built-in display | `2056 x 1329` | `2056 x 1291` |

Steps:

1. Start a middle-button direction-tiling gesture on a window located on the built-in display.
2. Select a zone on the Studio Display in the multi-display Bento overlay.
3. Observe that the red preview outline uses the correct full target height.
4. Release the mouse button.

Before this change, the moved window was only about `1291 pt` tall instead of the `1410 pt` preview target, leaving approximately `119 pt` at the bottom. Although the gap looked similar to reserved Dock space, the Dock was on the left; the gap matched the difference between the source and destination displays' available heights.

## macOS 26 vs macOS 27

The same scenario was reported not to reproduce on macOS 26.

The existing `Size -> Position -> Size` sequence relies on WindowServer recognizing the destination display before the final size write:

1. The first size write occurs while the window still belongs to the built-in display and is constrained to its `1291 pt` visible height.
2. The position write moves the window to the Studio Display.
3. The final size write should expand it to the Studio Display's `1410 pt` visible height.

On macOS 26, the destination display assignment appears to be updated in time for step 3. On macOS 27, that assignment is asynchronous: the immediate final size write is still constrained using the source display, so the window retains the shorter height.

An immediate cross-screen `Position -> Size` sequence was also tested on macOS 27, but it did not bypass the asynchronous display assignment. Accessibility exposes position and size as separate attributes and has no public atomic full-frame setter, so a reliable fix must wait briefly for WindowServer to settle.

## Changes

- Detect whether middle-button direction tiling is crossing between two displays.
- On macOS 27 and later, write only the target position first.
- Wait `100 ms`, then verify that the window center is on the intended destination display.
- Apply the final target size and position after destination assignment is confirmed.
- Keep the red target overlay visible during this short transition, then hide it immediately after the final frame write. This makes the asynchronous placement visually coherent instead of briefly presenting the source-constrained result as final.
- Hide the overlay on cancellation, permission failure, window lookup failure, and destination verification failure so it cannot become stranded.
- Extract the existing `AXEnhancedUserInterface` workaround into a helper so both the normal and deferred frame mutation paths preserve Electron compatibility.

## Scope and compatibility

The deferred path requires all of the following:

- macOS major version 27 or later
- A middle-button direction-tiling action
- Source and destination window centers on different displays

macOS 26 and earlier continue to use the original immediate `setWindowFrame` sequence. Same-display direction tiling also remains immediate on every macOS version. Normal modifier dragging and right-click tiling are unchanged.

## Verification

- Reproduced the bottom gap on macOS 27 with the display geometry above.
- Confirmed that immediate `Position -> Size` still reproduces the source-display height constraint.
- Confirmed on macOS 27 that deferred final sizing fills the red preview target and that retaining the overlay during the transition provides an acceptable visual result.
- Built both Debug and Release configurations successfully with signing disabled.

Existing Swift 6 `Sendable` diagnostics remain warnings and are unrelated to this change.
