### PR TITLE
ci: pin third-party actions in build.yml to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable
 
@@ -321,7 +321,7 @@ jobs:
           fi
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         if: startsWith(github.ref, 'refs/tags/v')
         with:
           files: |
@@ -354,7 +354,7 @@ jobs:
 
       - name: Trigger Homebrew Tap Update
         if: ${{ startsWith(github.ref, 'refs/tags/v') && env.HAS_HOMEBREW_PAT == 'true' && success() }}
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           # Cross-repo dispatch needs a PAT (the default GITHUB_TOKEN can only
           # dispatch inside this repo). The receiving workflow lives at


### PR DESCRIPTION
Resolves item 1 of #36.

## What

Pins the three third-party actions used by `.github/workflows/build.yml` to immutable commit SHAs:

| Action | Was | Now | Version |
|---|---|---|---|
| `maxim-lobanov/setup-xcode` | `@v1` | `ed7a3b1fda3918c0306d1b724322adc0b8cc0a90` | v1.7.0 |
| `softprops/action-gh-release` | `@v2` | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` | v2.6.2 |
| `peter-evans/repository-dispatch` | `@v3` | `ff45666b9427631e3450c54a1bcbee4d9ff4d7c0` | v3.0.0 |

`actions/checkout@v4` and `actions/upload-artifact@v4` are left alone — GitHub-owned, and CodeQL deliberately does not flag them.

## Why

The build job holds the Developer ID signing certificate, the notarization credentials, the Sparkle EdDSA private key, and a cross-repo PAT. A major tag is mutable: the action owner, or anyone who compromises their account, can repoint `@v2` at new code, and that code then runs with access to all of those secrets. A commit SHA cannot be repointed.

Should close CodeQL alerts #2, #3, #4.

## Behaviour change: none

Each SHA is the commit that the action's current major tag already resolves to as of this PR, cross-checked against the newest release under that major (`v1` = v1.7.0, `v2` = v2.6.2, `v3` = v3.0.0 — all three matched). No version upgrades here.

## Note for reviewers

- **This conflicts with Dependabot PR #37**, which wants to bump these same three actions across major versions (gh-release v2 -> v3, repository-dispatch v3 -> v4). #37 is untouched and will need rebasing or reopening after whichever lands first.
- **CI on this PR does not exercise two of the three pins.** The `Release` and `Trigger Homebrew Tap Update` steps are gated on `startsWith(github.ref, 'refs/tags/v')`, so they are skipped on pull requests. A green PR run only proves the `setup-xcode` pin works; the other two are first exercised on the next version tag push.