### PR TITLE
feat(resize): allow contained resize modifiers

### DIFF
--- a/AnyDrag/Sources/DragEngine.swift
+++ b/AnyDrag/Sources/DragEngine.swift
@@ -100,18 +100,23 @@ struct ModifierCombination: OptionSet, Equatable, Hashable {
         Self.augmentCandidates.contains(self)
     }
 
-    /// First eligible secondary key that doesn't overlap `base`, so the resize
-    /// trigger can never collide with the move trigger (the base modifier).
+    /// First eligible secondary key that isn't identical to `base`. A key may
+    /// overlap a multi-key base because both gestures use exact flag matching.
     static func defaultAugment(excluding base: ModifierCombination) -> ModifierCombination {
-        augmentCandidates.first { $0.isDisjoint(with: base) } ?? .shift
+        augmentCandidates.first { $0.isValidAugment(for: base) } ?? .shift
     }
 
-    /// Normalize a persisted/hand-edited augment for the given base: keep it if
-    /// it's a single eligible key disjoint from the base, otherwise fall back to
-    /// the first non-conflicting default. Guarantees the engine never arms the
-    /// resize path on the same flags as the move path.
+    /// True when this is a valid secondary key whose final shortcut is not
+    /// identical to the move shortcut. A single key contained in a multi-key
+    /// base remains valid because both matchers require exact flag equality.
+    func isValidAugment(for base: ModifierCombination) -> Bool {
+        isValidAugment && self != base
+    }
+
+    /// Normalize a persisted/hand-edited augment for the given base, preserving
+    /// contained keys while preventing identical move and resize shortcuts.
     func sanitizedAugment(base: ModifierCombination) -> ModifierCombination {
-        (isValidAugment && isDisjoint(with: base)) ? self : Self.defaultAugment(excluding: base)
+        isValidAugment(for: base) ? self : Self.defaultAugment(excluding: base)
     }
 
     /// Migrate the pre-1.3 `ModifierKey` string preference.
@@ -216,8 +221,8 @@ final class DragEngine {
     var leftResizeEnabled: Bool { resizeTrigger == .leftClick }
     /// The single secondary key that triggers a left-click resize on its own
     /// (e.g. `.shift` → Shift + left-drag resizes; the primary modifier is not
-    /// required). Always kept disjoint from `modifiers` so this trigger can
-    /// never collide with the move gesture — see `sanitizedAugment(base:)`.
+    /// required). It may be contained in a multi-key move modifier, but may not
+    /// be identical to it — see `sanitizedAugment(base:)`.
     var leftResizeModifier: ModifierCombination = .shift
     /// When true (default) and ≥2 displays are connected, the bento panel
     /// renders all displays at their real arrangement so the user can pick
@@ -1947,8 +1952,7 @@ final class DragEngine {
     /// the primary modifier is NOT required (it gates only the move/right-resize
     /// gestures). Returns false (so the event falls through to the move/maximize
     /// path) whenever the feature is off, the app has no primary modifier
-    /// configured (effectively off), or the secondary would overlap the base —
-    /// which keeps the move gesture working no matter how the two are configured.
+    /// configured (effectively off), or the secondary is identical to the base.
     private func matchesLeftResizeModifier(_ flags: CGEventFlags) -> Bool {
         guard leftResizeEnabled else { return false }
         // No primary modifier configured means AnyDrag is off; don't arm resize
@@ -1956,10 +1960,10 @@ final class DragEngine {
         // non-empty for a Hyper/CapsLock base, whose eventFlags are empty.)
         guard !modifiers.isEmpty else { return false }
         let augment = leftResizeModifier
-        // The secondary must be a single real flag key that isn't already part
-        // of the base — otherwise "secondary alone" could collide with the move
-        // trigger (which arms on the base).
-        guard augment.isValidAugment, augment.isDisjoint(with: modifiers) else { return false }
+        // The secondary must be a single real flag key and must not be identical
+        // to the move shortcut. Containment in a multi-key base is safe because
+        // both paths use exact flag matching.
+        guard augment.isValidAugment(for: modifiers) else { return false }
         let augmentFlags = augment.eventFlags
         guard !augmentFlags.isEmpty else { return false }
 

--- a/AnyDrag/Sources/Preferences.swift
+++ b/AnyDrag/Sources/Preferences.swift
@@ -334,8 +334,8 @@ enum Preferences {
 
         // Secondary modifier for the "left" trigger. Read after `modifiers` so
         // the augment can be sanitized against the (now-known) base — it must
-        // stay a single valid key disjoint from the base, else the resize
-        // trigger wouldn't differ from the move trigger.
+        // stay a single valid key whose final shortcut differs from the move
+        // trigger, while containment in a multi-key base remains valid.
         if let raw = d.object(forKey: Key.leftResizeModifier) as? UInt {
             engine.leftResizeModifier = ModifierCombination(rawValue: raw).sanitizedAugment(base: engine.modifiers)
         } else {

--- a/AnyDrag/Sources/Settings/PreferencesWindowController.swift
+++ b/AnyDrag/Sources/Settings/PreferencesWindowController.swift
@@ -14,10 +14,10 @@ import ApplicationServices
 //   3. `Analytics.trackPreferenceChanged` (only on an actual value change).
 //
 // All the subtle invariants the panes enforced are preserved here: Hyper is
-// exclusive with the flag modifiers, the left-resize augment is kept disjoint
-// from the base, and the corner-bracket / tile sub-options gate on their parent
-// selection. The views stay dumb — they read these properties and call the
-// `set*` methods; the store owns the rules.
+// exclusive with the flag modifiers, the left-resize shortcut stays distinct
+// from the primary shortcut, and the corner-bracket / tile sub-options gate on
+// their parent selection. The views stay dumb — they read these properties and
+// call the `set*` methods; the store owns the rules.
 //
 // Not actor-isolated: it is only ever touched on the main thread — SwiftUI
 // bindings run on main, and every notification observer below uses `queue:
@@ -150,8 +150,8 @@ final class SettingsStore: ObservableObject {
         modifiers = proposed
         UserDefaults.standard.set(proposed.rawValue, forKey: Preferences.Key.modifierFlags)
 
-        // Keep the secondary a single eligible key disjoint from the new base so
-        // the left-resize trigger can never collide with the move trigger.
+        // Keep the secondary a single eligible key distinct from the new base.
+        // It may remain contained in a multi-key base because matching is exact.
         let sanitized = engine.leftResizeModifier.sanitizedAugment(base: proposed)
         if sanitized != engine.leftResizeModifier {
             engine.leftResizeModifier = sanitized
@@ -167,19 +167,17 @@ final class SettingsStore: ObservableObject {
 
     // MARK: Left-resize augment (secondary modifier)
 
-    /// The keys forbidden in the augment picker — those already taken by the
-    /// base modifier (picking one would make the resize trigger identical to
-    /// the move trigger).
+    /// The key forbidden in the augment picker when the primary modifier is the
+    /// same single key. Keys contained in a multi-key primary remain available.
     var augmentDisabledElements: ModifierCombination {
-        let mask = ModifierCombination.augmentCandidates.reduce(into: ModifierCombination()) { $0.formUnion($1) }
-        return mask.intersection(modifiers)
+        modifiers.isValidAugment ? modifiers : []
     }
 
     /// Apply a proposed augment. Accepted only when it is a single eligible key
-    /// disjoint from the base — matching the old picker's validation.
+    /// whose final shortcut differs from the primary modifier.
     @discardableResult
     func setAugment(_ proposed: ModifierCombination) -> Bool {
-        guard proposed.isValidAugment, proposed.isDisjoint(with: modifiers) else { return false }
+        guard proposed.isValidAugment(for: modifiers) else { return false }
         let previous = engine.leftResizeModifier
         engine.leftResizeModifier = proposed
         leftResizeModifier = proposed


### PR DESCRIPTION
## 需求

允许窗口拖动与左键缩放的修饰键存在包含关系，只禁止两者的最终快捷键完全相同。

例如：

- `Control` + 左键拖动：缩放窗口
- `Control + Command` + 左键拖动：移动窗口

## 历史原因

左键缩放最初在 [`42b3c30`](https://github.com/XueshiQiao/AnyDrag/commit/42b3c3049e38313f3cd98e401307a3142ab4f93d) 中实现为“主修饰键 + 辅助修饰键 + 左键拖动”。在这个模型下，辅助键必须与主修饰键不相交，否则两套最终组合可能完全相同，因此当时的 `isDisjoint` 约束是必要的。

随后 [`d374737`](https://github.com/XueshiQiao/AnyDrag/commit/d374737594a7345e63d69e91973ef879dc9022fd) 将左键缩放改成“缩放修饰键单独按下 + 左键拖动”，但设置界面、配置清洗和运行时保护仍保留了原来的“不相交”约束。

当前移动和缩放匹配器都要求修饰键精确相等，所以 `Control` 与 `Control + Command` 可以直接区分，不需要新增最长匹配或改变事件分发顺序。

## 改动

- 将左键缩放修饰键规则统一为：必须是合法单键，且不能与主修饰键完全相同。
- 多键主修饰键不再禁用其包含的单键缩放修饰键。
- 修改主修饰键或读取持久化配置时，保留合法的包含关系。
- 运行时仍拒绝完全相同的快捷键。
- 保持现有精确匹配、`Option` 候选限制和 `Hyper` 逻辑不变。

## 验证

- `xcodegen generate`
- `xcodebuild -project AnyDrag.xcodeproj -scheme AnyDrag -configuration Debug CODE_SIGNING_ALLOWED=NO build`
- 规则矩阵验证：包含关系允许、完全相同拒绝、无交集继续允许，配置清洗只替换完全相同的组合。

Closes #46
